### PR TITLE
Feature/card for usprotests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "visualization"
   ],
   "license": "Do No Harm",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "./dist/react.js",
   "module": "./dist/react.esm.js",
   "files": [

--- a/src/lib/components/Card/Card.React.js
+++ b/src/lib/components/Card/Card.React.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import CardCustomField from "./atoms/CustomField";
 import CardTime from "./atoms/Time";
-import CardLocation from "./atoms/Location";
+import { CardLocation, CardLocationPrecision } from "./atoms/Location";
 import CardCaret from "./atoms/Caret";
 import CardSummary from "./atoms/Summary";
 import CardSource from "./atoms/Source";
@@ -57,6 +57,10 @@ export const Card = ({
     );
   };
 
+  const renderLocationPrecision = () => {
+    return <CardLocationPrecision type={event["location_precision"]} />;
+  };
+
   const renderSources = () => {
     if (sourceError) {
       return <div>ERROR: something went wrong loading sources, TODO:</div>;
@@ -90,6 +94,15 @@ export const Card = ({
     );
   };
 
+  const renderAssociations = () => {
+    return (
+      <div>
+        <h4>Type of violation</h4>
+        <span>{event.associations.join(" / ")}</span>
+      </div>
+    );
+  };
+
   const renderCustomFields = () => {
     return customEventFields.map((field) => {
       const value = event[field.key];
@@ -106,17 +119,17 @@ export const Card = ({
     </>
   );
 
-  const renderMain = () => {
-    // return null;
-    return (
-      <>
-        {renderContextual()}
-        {/* <br /> */}
-        {renderSummary()}
-        {renderCustomFields()}
-      </>
-    );
-  };
+  // const renderMain = () => {
+  //   // return null;
+  //   return (
+  //     <>
+  //       {renderContextual()}
+  //       {/* <br /> */}
+  //       {renderSummary()}
+  //       {renderCustomFields()}
+  //     </>
+  //   );
+  // };
 
   // const renderExtra = () => {
   //   return <div className="card-bottomhalf">{renderSources()}</div>;
@@ -129,14 +142,30 @@ export const Card = ({
     return <CardMedia src={event.sources[0].paths[0]} />;
   };
 
+  // TODO make renderList and renderListInline curried functions
+  const renderLawEnforcementAgencies = () => {
+    return event["le_agencys"].length ? (
+      <div>
+        <h4>Law Enforcement Agencies</h4>
+        {event["le_agencys"].map((item, idx) => (
+          <div key={`le_agencies_${idx}`}>{item}</div>
+        ))}
+      </div>
+    ) : null;
+  };
+
   const renderFunctions = {
-    renderSummary,
-    renderLocation,
-    renderSources,
-    renderTime,
+    // renderIncidentId,
+    renderAssociations,
     renderCustomFields,
     renderContextual,
+    renderLawEnforcementAgencies,
+    renderLocation,
+    renderLocationPrecision,
     renderMedia,
+    renderSources,
+    renderSummary,
+    renderTime,
   };
 
   return (

--- a/src/lib/components/Card/Card.React.js
+++ b/src/lib/components/Card/Card.React.js
@@ -61,6 +61,57 @@ export const Card = ({
     return <CardLocationPrecision type={event["location_precision"]} />;
   };
 
+  const renderNetwork = () => {
+    return (
+      // <div className="card-col">
+      event["news_organisation"] && (
+        <div className="card-cell">
+          <>
+            <h4>Network</h4>
+            {event["news_organisation"]}
+          </>
+        </div>
+      )
+    );
+  };
+
+  const renderReporter = () => {
+    return (
+      // <div className="card-col">
+      event["journalist_name"] && (
+        <div className="card-cell">
+          <>
+            <h4>Name of Reporter/s</h4>
+            {event["journalist_name"]}
+          </>
+        </div>
+      )
+    );
+  };
+
+  // TODO make boolean in backend
+  // TODO Add source URL
+  const renderUSProtestsSource = () => {
+    return (
+      <>
+        <h4>Source</h4>
+        <div>
+          {event["hide_source"] === `TRUE` ? (
+            <span>
+              Source hidden to protect the privacy and dignity of civilians.
+              Read more{" "}
+              <a href="https://staging.forensic-architecture.org/wp-content/uploads/2020/09/2020.14.09-FA-Bcat-Mission-Statement.pdf">
+                here
+              </a>
+            </span>
+          ) : (
+            <span>TODO: Add source URL</span>
+          )}
+        </div>
+      </>
+    );
+  };
+
   const renderSources = () => {
     if (sourceError) {
       return <div>ERROR: something went wrong loading sources, TODO:</div>;
@@ -163,6 +214,9 @@ export const Card = ({
     renderLocation,
     renderLocationPrecision,
     renderMedia,
+    renderNetwork,
+    renderReporter,
+    renderUSProtestsSource,
     renderSources,
     renderSummary,
     renderTime,

--- a/src/lib/components/Card/atoms/Location.js
+++ b/src/lib/components/Card/atoms/Location.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import copy from "../../../data/copy.json";
 
-const CardLocation = ({ language, location, isPrecise }) => {
+export const CardLocation = ({ language, location, isPrecise }) => {
   if (location !== "") {
     return (
       <div className="card-cell location">
@@ -27,4 +27,32 @@ const CardLocation = ({ language, location, isPrecise }) => {
   }
 };
 
-export default CardLocation;
+export const CardLocationPrecision = ({ type }) => {
+  switch (type) {
+    case `Confirmed`:
+      return null;
+    case `Generalised`:
+      return (
+        <>
+          <em>No precise location data available.</em>
+        </>
+      );
+    case `Estimated`:
+      return (
+        <>
+          <span>
+            This location is an estimate; precise location could not be
+            verified.
+          </span>
+        </>
+      );
+    case `Self-reported`:
+      return (
+        <>
+          <span>This location was reported by a witness.</span>
+        </>
+      );
+    default:
+      return null;
+  }
+};

--- a/src/lib/styles/card.scss
+++ b/src/lib/styles/card.scss
@@ -4,6 +4,7 @@
   padding: 15px;
   transition: 0.2 ease;
   background: $midwhite;
+  opacity: 0.92;
   color: $darkgrey;
   list-style-type: none;
   font-size: $large;


### PR DESCRIPTION
Extremely hacky with non-abstracted functionality 🥺. This is happening because I decided to only pass function names as strings from the timemap configs. If we pass objects instead, we can specify accessors and headlines / fallbacks with curried functions. Now that I know the types of information we might be showing it'll be easier to come up with abstractions for displaying relevant information.