### PR TITLE
Card Layout Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 dist/
+public/assets/fonts/GT-Zirkon*
 
 # storybook
 storybook-static

--- a/src/lib/components/Card/Card.React.js
+++ b/src/lib/components/Card/Card.React.js
@@ -7,7 +7,6 @@ import CardCaret from "./atoms/Caret";
 import CardCustom from "./atoms/CustomField";
 import CardMedia from "./atoms/Media";
 
-import copy from "../../data/copy.json";
 import { makeNiceDate, isEmptyString } from "../../utils";
 
 export const Card = ({

--- a/src/lib/components/Card/Card.stories.js
+++ b/src/lib/components/Card/Card.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Card } from "./Card.React";
+import { generateCardLayout } from "../../templates";
 import { CardProps } from "../../../test/Card";
 
 const Template = (args) => <Card {...args} />;
@@ -10,13 +11,22 @@ TextOnly.args = {
   ...CardProps,
 };
 
-console.log(CardProps);
-
 const addInlineMedia = (props, src) => {
   return {
     ...props,
     content: [...props.content, [{ kind: "media", src }]],
   };
+};
+
+export const BasicLayoutTemplate = Template.bind({});
+BasicLayoutTemplate.args = {
+  content: generateCardLayout["basic"]({
+    event: {
+      datetime: new Date(),
+      location: `Somewhere`,
+      description: `Something happened`,
+    },
+  }),
 };
 
 export const InlineVideoPortrait = Template.bind({});

--- a/src/lib/index.react.js
+++ b/src/lib/index.react.js
@@ -4,3 +4,4 @@ export { Button } from "./components/Button/Button.React.js";
 export { Card } from "./components/Card/Card.React.js";
 export { CardStack } from "./components/CardStack/CardStack.React.js";
 export { Spinner } from "./atoms/Spinner.React.js";
+export { generateCardLayout } from "./templates/";

--- a/src/lib/templates/card.js
+++ b/src/lib/templates/card.js
@@ -1,0 +1,133 @@
+export const generateCardLayout = {
+  basic: ({ event }) => {
+    return [
+      [
+        {
+          kind: "date",
+          title: "Incident Date",
+          value: event.datetime || event.date || ``,
+        },
+        {
+          kind: "text",
+          title: "Location",
+          value: event.location || `—`,
+        },
+      ],
+      [{ kind: "line-break", times: 0.4 }],
+      [
+        {
+          kind: "text",
+          title: "Summary",
+          value: event.description || ``,
+          scaleFont: 1.1,
+        },
+      ],
+    ];
+  },
+  us_protests: ({ event, colors, coloringSet, getFilterIdxFromColorSet }) => {
+    let precision;
+    switch (event.location_precision) {
+      case `Generalised`:
+        precision = `No location data`;
+        break;
+      case `Estimated`:
+        precision = `Precise location estimated`;
+        break;
+      case `Self-reported`:
+        precision = `Location reported by witness`;
+        break;
+      case `Confirmed`:
+      default:
+        precision = null;
+        break;
+    }
+
+    return [
+      [
+        {
+          kind: "tag",
+          align: "end",
+          value: `Incident #${event.incident_id}`,
+        },
+      ],
+      [{ kind: "line" }],
+      [
+        { kind: "date", title: "Incident Date", value: event.datetime },
+        {
+          kind: "text",
+          title: "Location",
+          hoverValue: precision,
+          value: event.location,
+        },
+      ],
+      [{ kind: "line-break", times: 0.4 }],
+      [
+        {
+          kind: "text",
+          title: "Summary",
+          value: event.description,
+          scaleFont: 1.1,
+        },
+      ],
+      [{ kind: "line-break", times: 0.4 }],
+      [
+        {
+          kind: "button",
+          title: "Type of Violation",
+          value: event.associations.slice(0, -1).map((association) => ({
+            text: association,
+            color:
+              getFilterIdxFromColorSet(association, coloringSet) >= 0
+                ? colors[getFilterIdxFromColorSet(association, coloringSet)]
+                : null,
+            normalCursor: true,
+          })),
+        },
+        {
+          kind: "button",
+          title: "Against",
+          value: event.associations.slice(-1).map((category) => ({
+            text: category,
+            color: null,
+            normalCursor: true,
+          })),
+        },
+      ],
+      [{ kind: "line-break", times: 0.2 }],
+      [
+        {
+          kind: "list",
+          title: "Law Enforcement Agencies",
+          value: event.le_agencys,
+        },
+      ],
+      [
+        {
+          kind: "text",
+          title: "Name of reporter(s)",
+          value: event.journalist_name,
+        },
+        {
+          kind: "text",
+          title: "Network",
+          value: event.news_organisation,
+        },
+      ],
+      [
+        {
+          kind: event.hide_source === "FALSE" ? "button" : "markdown",
+          title: "Sources",
+          value:
+            event.hide_source === "FALSE"
+              ? event.links.map((href, idx) => ({
+                  text: `Source ${idx + 1}`,
+                  href,
+                  color: null,
+                  onClick: () => window.open(href, "_blank"),
+                }))
+              : "Source hidden to protect the privacy and dignity of civilians. Read more [here](https://staging.forensic-architecture.org/wp-content/uploads/2020/09/2020.14.09-FA-Bcat-Mission-Statement.pdf).",
+        },
+      ],
+    ];
+  },
+};

--- a/src/lib/templates/index.js
+++ b/src/lib/templates/index.js
@@ -1,0 +1,1 @@
+export * from "./card";


### PR DESCRIPTION
The idea behind this is, since these card layouts can't be specified at runtime from the specified CONFIG file in Timemap, they will be retrievable by key from our design system. The default card layout in Timemap's initial store will be the `basic` template. Given the restrictions we've run against, I believe this is the only way forward.

The corresponding part of the CONFIG file in timemap will look like this: 
```
{
  ...,
  ui: { card: { template: `basic` } }
}
```